### PR TITLE
Change project namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@ $redis = new \Redis();
 $redis->connect('yourhost', 6379);
 $redis->auth(['user' => 'youruser', 'pass' => 'yourpass']);
 
-$cache = new \Firehed\Redis\RedisPsr16($redis);
+$cache = new \Firehed\Cache\RedisPsr16($redis);
 // Use like any other PSR-16 implementation
 ```

--- a/composer.json
+++ b/composer.json
@@ -19,12 +19,12 @@
     "type": "library",
     "autoload": {
         "psr-4": {
-            "Firehed\\Redis\\": "src"
+            "Firehed\\Cache\\": "src"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Firehed\\Redis\\": [
+            "Firehed\\Cache\\": [
                 "tests/unit",
                 "tests/integration"
             ]

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Firehed\Redis;
+namespace Firehed\Cache;
 
 use RedisException;
 use RuntimeException;

--- a/src/RedisPsr16.php
+++ b/src/RedisPsr16.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Firehed\Redis;
+namespace Firehed\Cache;
 
 use Psr\SimpleCache\CacheInterface;
 use Redis;

--- a/src/TypeException.php
+++ b/src/TypeException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Firehed\Redis;
+namespace Firehed\Cache;
 
 use LogicException;
 use Psr\SimpleCache\InvalidArgumentException;

--- a/tests/integration/IntegrationTest.php
+++ b/tests/integration/IntegrationTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Firehed\Redis;
+namespace Firehed\Cache;
 
 use Redis;
 
@@ -12,7 +12,7 @@ use function assert;
 use function getenv;
 
 /**
- * @covers Firehed\Redis\RedisPsr16
+ * @covers Firehed\Cache\RedisPsr16
  */
 class IntegrationTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/unit/RedisPsr16Test.php
+++ b/tests/unit/RedisPsr16Test.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Firehed\Redis;
+namespace Firehed\Cache;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use Redis;
@@ -11,7 +11,7 @@ use function array_keys;
 use function array_map;
 
 /**
- * @covers Firehed\Redis\RedisPsr16
+ * @covers Firehed\Cache\RedisPsr16
  */
 class RedisPsr16Test extends \PHPUnit\Framework\TestCase
 {


### PR DESCRIPTION
Moving to `Firehed\Cache` (from `Firehed\Redis`) to support keeping shared code across drivers in a single namespace.