### PR TITLE
Support different operational modes for handling network errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,16 @@ $redis->auth(['user' => 'youruser', 'pass' => 'yourpass']);
 $cache = new \Firehed\Cache\RedisPsr16($redis);
 // Use like any other PSR-16 implementation
 ```
+
+### Configuration
+
+A runtime mode can be set via the `$mode` constructor parameter.
+
+- `RedisPsr16::MODE_THROW` may throw exceptions on network issues (in the same way directly using the `Redis` extension can).
+  Exceptions thrown will implement `Psr\SimpleCache\CacheException`, per PSR-16 requirements.
+  This will help expose networking issues and may be beneficial for logging and error handling, but does require calling libraries to handle them.
+  _This is the default mode._
+
+- `RedisPsr16::MODE_FAIL` will prevent exceptions from being thrown.
+  Any error, including networking errors (where the `Redis` extension throws) will be treated as a failure.
+  This could result in misleading behavior around cache misses; if it's important for your application to know the difference between "miss" and "Redis unavailable", do not use this mode.

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,6 +6,8 @@ parameters:
     ignoreErrors:
         # This is unfixable without an upstream change to the interface.
         - '#Multiple\(\) should be contravariant with parameter#'
+        # Same
+        - '#^Parameter \#1 \$exception of method PHPUnit\\Framework\\TestCase::expectException\(\) expects class-string<Throwable>, string given.$#'
     level: max
     paths:
         - .

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,7 +5,7 @@
          cacheResultFile=".phpunit.cache/test-results"
          executionOrder="depends,defects"
          forceCoversAnnotation="true"
-         beStrictAboutCoversAnnotation="true"
+         beStrictAboutCoversAnnotation="false"
          beStrictAboutOutputDuringTests="true"
          beStrictAboutTodoAnnotatedTests="true"
          failOnRisky="true"

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -8,6 +8,10 @@ use RedisException;
 use RuntimeException;
 use Psr\SimpleCache\CacheException;
 
+/**
+ * @internal - client code should only look for PSR exceptions, not these
+ * specific implementations.
+ */
 class Exception extends RuntimeException implements CacheException
 {
     public const ERROR_PING = 1;

--- a/src/RedisPsr16.php
+++ b/src/RedisPsr16.php
@@ -158,6 +158,9 @@ class RedisPsr16 implements CacheInterface
      */
     private function handleException(RedisException $e): bool
     {
-        return false;
+        return match ($this->mode) {
+            self::MODE_THROW => throw new Exception(Exception::ERROR_GONE, $e),
+            self::MODE_FAIL => false,
+        };
     }
 }

--- a/src/TypeException.php
+++ b/src/TypeException.php
@@ -7,6 +7,10 @@ namespace Firehed\Cache;
 use LogicException;
 use Psr\SimpleCache\InvalidArgumentException;
 
+/**
+ * @internal - client code should only look for PSR exceptions, not these
+ * specific implementations.
+ */
 class TypeException extends LogicException implements InvalidArgumentException
 {
 }

--- a/tests/unit/ModeFailTest.php
+++ b/tests/unit/ModeFailTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\Cache;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\SimpleCache\{
+    CacheException,
+    CacheInterface,
+};
+use Redis;
+use RedisException;
+
+/**
+ * @covers Firehed\Cache\RedisPsr16
+ */
+class ModeFailTest extends \PHPUnit\Framework\TestCase
+{
+    /** @var Redis&MockObject $redis */
+    private Redis $redis;
+
+    private RedisPsr16 $cache;
+
+    public function setUp(): void
+    {
+        $ex = new RedisException();
+
+        $this->redis = $this->createMock(Redis::class);
+        $methods = [
+            'get',
+            'mget',
+            'set',
+            'setex',
+            'del',
+            'mset',
+            'exists',
+            'flushAll',
+            'flushDb',
+        ];
+        foreach ($methods as $method) {
+            $this->redis->method($method)
+                ->willThrowException($ex);
+        }
+        $this->cache = new RedisPsr16($this->redis, RedisPsr16::MODE_FAIL);
+    }
+
+    public function testConstructDoesNotThrow(): void
+    {
+        // Bypasses normal setup code
+        $redis = $this->createMock(Redis::Class);
+        $redis->method('ping')
+            ->willThrowException(new RedisException());
+        $cache = new RedisPsr16($redis, RedisPsr16::MODE_FAIL);
+        self::assertInstanceOf(CacheInterface::class, $cache);
+    }
+
+    public function testGetReturnsDefaultNull(): void
+    {
+        self::assertNull($this->cache->get('key'));
+    }
+
+    public function testGetReturnsDefaultValue(): void
+    {
+        self::assertSame(
+            'default',
+            $this->cache->get('key', 'default'),
+        );
+    }
+
+    public function testSetFails(): void
+    {
+        self::assertFalse($this->cache->set('key', 'value'));
+    }
+
+    public function testDeleteFails(): void
+    {
+        self::assertFalse($this->cache->delete('key'));
+    }
+
+    public function testClearFails(): void
+    {
+        self::assertFalse($this->cache->clear());
+    }
+
+    public function testGetMultipleReturnsDefaultNull(): void
+    {
+        self::assertSame(
+            ['key1' => null, 'key2' => null],
+            $this->cache->getMultiple(['key1', 'key2']),
+        );
+    }
+
+    public function testGetMultipleReturnsDefaultValue(): void
+    {
+        self::assertSame(
+            ['key1' => 'default', 'key2' => 'default'],
+            $this->cache->getMultiple(['key1', 'key2'], 'default'),
+        );
+    }
+
+    public function testSetMultipleFails(): void
+    {
+        self::assertFalse($this->cache->setMultiple(['key1' => 'value1', 'key2' => 'value2']));
+    }
+
+    public function testDeleteMultipleFails(): void
+    {
+        self::assertFalse($this->cache->deleteMultiple(['key1', 'key2']));
+    }
+
+    public function testHasFails(): void
+    {
+        self::assertFalse($this->cache->has('key'));
+    }
+}

--- a/tests/unit/ModeFailTest.php
+++ b/tests/unit/ModeFailTest.php
@@ -104,6 +104,11 @@ class ModeFailTest extends \PHPUnit\Framework\TestCase
         self::assertFalse($this->cache->setMultiple(['key1' => 'value1', 'key2' => 'value2']));
     }
 
+    public function testSetMultipleTtlFails(): void
+    {
+        self::assertFalse($this->cache->setMultiple(['key1' => 'value1', 'key2' => 'value2'], 30));
+    }
+
     public function testDeleteMultipleFails(): void
     {
         self::assertFalse($this->cache->deleteMultiple(['key1', 'key2']));

--- a/tests/unit/ModeThrowTest.php
+++ b/tests/unit/ModeThrowTest.php
@@ -88,6 +88,13 @@ class ModeThrowTest extends \PHPUnit\Framework\TestCase
         $this->cache->setMultiple(['key1' => 'value1', 'key2' => 'value2']);
     }
 
+    public function testSetMultipleTtlThrows(): void
+    {
+        self::expectException(CacheException::class);
+        $this->cache->setMultiple(['key1' => 'value1', 'key2' => 'value2'], 30);
+    }
+
+
     public function testDeleteMultipleThrows(): void
     {
         self::expectException(CacheException::class);

--- a/tests/unit/ModeThrowTest.php
+++ b/tests/unit/ModeThrowTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\Cache;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\SimpleCache\CacheException;
+use Redis;
+use RedisException;
+
+/**
+ * @covers Firehed\Cache\RedisPsr16
+ */
+class ModeThrowTest extends \PHPUnit\Framework\TestCase
+{
+    /** @var Redis&MockObject $redis */
+    private Redis $redis;
+
+    private RedisPsr16 $cache;
+
+    public function setUp(): void
+    {
+        $ex = new RedisException();
+
+        $this->redis = $this->createMock(Redis::class);
+        $methods = [
+            'get',
+            'mget',
+            'set',
+            'setex',
+            'del',
+            'mset',
+            'exists',
+            'flushAll',
+            'flushDb',
+        ];
+        foreach ($methods as $method) {
+            $this->redis->method($method)
+                ->willThrowException($ex);
+        }
+        $this->cache = new RedisPsr16($this->redis, RedisPsr16::MODE_THROW);
+    }
+
+    public function testConstructThrows(): void
+    {
+        // Bypasses normal setup code
+        $redis = $this->createMock(Redis::Class);
+        $redis->method('ping')
+            ->willThrowException(new RedisException());
+        self::expectException(CacheException::class);
+        new RedisPsr16($redis, RedisPsr16::MODE_THROW);
+    }
+
+    public function testGetThrows(): void
+    {
+        self::expectException(CacheException::class);
+        $this->cache->get('key');
+    }
+
+    public function testSetThrows(): void
+    {
+        self::expectException(CacheException::class);
+        $this->cache->set('key', 'value');
+    }
+
+    public function testDeleteThrows(): void
+    {
+        self::expectException(CacheException::class);
+        $this->cache->delete('key');
+    }
+
+    public function testClearThrows(): void
+    {
+        self::expectException(CacheException::class);
+        $this->cache->clear();
+    }
+
+    public function testGetMultipleThrows(): void
+    {
+        self::expectException(CacheException::class);
+        $this->cache->getMultiple(['key1', 'key2']);
+    }
+
+    public function testSetMultipleThrows(): void
+    {
+        self::expectException(CacheException::class);
+        $this->cache->setMultiple(['key1' => 'value1', 'key2' => 'value2']);
+    }
+
+    public function testDeleteMultipleThrows(): void
+    {
+        self::expectException(CacheException::class);
+        $this->cache->deleteMultiple(['key1', 'key2']);
+    }
+
+    public function testHasThrows(): void
+    {
+        self::expectException(CacheException::class);
+        $this->cache->has('key');
+    }
+}


### PR DESCRIPTION
See README changes for details. In short: adds `MODE_THROW` and `MODE_FAIL` to make fallback stuff easier