### PR TITLE
Fix serialization; add more integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,23 @@ $cache = new \Firehed\Cache\RedisPsr16($redis);
 If `Redis::OPT_SERIALIZER` is not set (or uses the default `Redis::SERIALIZER_NONE`), this library will automatically set it to `Redis::SERIALIZER_PHP`.
 This will ensure that non-string values are stored and retreived correctly.
 Be aware that this means if any `object`s are cached, any magic methods related to serialization (`__sleep()`, `__wakeup()`, `__serialize()`, `__unserialize()`) will be called during caching operations.
+Setting that option to any other value before providing Redis to this library will use the set serializer:
+
+```php
+use Firehed\Cache\RedisPsr16;
+use Redis;
+
+// Automatically sets SERIALIZER_PHP:
+$redis = new Redis();
+// connect/auth
+$cache = new RedisPsr16($redis);
+
+// Uses specified SERIALIZER_JSON
+$redis = new Redis();
+// connect/auth
+$redis->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_JSON);
+$cache = new RedisPsr16($redis);
+```
 
 ### Configuration
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ $cache = new \Firehed\Cache\RedisPsr16($redis);
 // Use like any other PSR-16 implementation
 ```
 
+If `Redis::OPT_SERIALIZER` is not set (or uses the default `Redis::SERIALIZER_NONE`), this library will automatically set it to `Redis::SERIALIZER_PHP`.
+This will ensure that non-string values are stored and retreived correctly.
+Be aware that this means if any `object`s are cached, any magic methods related to serialization (`__sleep()`, `__wakeup()`, `__serialize()`, `__unserialize()`) will be called during caching operations.
+
 ### Configuration
 
 A runtime mode can be set via the `$mode` constructor parameter:

--- a/src/RedisPsr16.php
+++ b/src/RedisPsr16.php
@@ -37,6 +37,9 @@ class RedisPsr16 implements CacheInterface
     {
         try {
             $this->conn->ping();
+            if ($this->conn->getOption(Redis::OPT_SERIALIZER) === Redis::SERIALIZER_NONE) {
+                $this->conn->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_PHP);
+            }
         } catch (RedisException $e) {
             // Abusing match slightly here, so if a new mode is added in the
             // future, static analysis will find it.

--- a/tests/integration/IntegrationTest.php
+++ b/tests/integration/IntegrationTest.php
@@ -59,6 +59,66 @@ class IntegrationTest extends \PHPUnit\Framework\TestCase
         self::assertEqualsCanonicalizing($data, $afterSetting);
     }
 
+    public function testObjectSerialization(): void
+    {
+        $object = new SampleObject(3, 'three', 3.14, true);
+        $cache = new RedisPsr16($this->redis);
+        $cache->set(__METHOD__, $object);
+        $response = $cache->get(__METHOD__);
+        self::assertEquals($object, $response, 'Object changed (loose equality)');
+    }
+
+    /**
+     * @dataProvider encodingValues
+     */
+    public function testValueSerialization(mixed $value): void
+    {
+        $cache = new RedisPsr16($this->redis);
+        $cache->set(__METHOD__, $value);
+        $response = $cache->get(__METHOD__);
+        self::assertSame($value, $response, 'Value changed when returned from cache');
+    }
+
+    /**
+     * @see https://www.php-fig.org/psr/psr-16/ Section 1.4
+     *
+     * > If it is not possible to return the exact saved value for any reason,
+     * > implementing libraries MUST respond with a cache miss rather than
+     * > corrupted data.
+     */
+    public function testFalseHandling(): void
+    {
+        $value = false;
+        $cache = new RedisPsr16($this->redis);
+        $cache->set(__METHOD__, $value);
+        $response = $cache->get(__METHOD__, 'default');
+        self::assertSame(
+            'default',
+            $response,
+            '`false` cannot be correctly retreived and must be treated as a cache miss',
+        );
+    }
+
+    /**
+     * @return array{mixed}[]
+     */
+    public function encodingValues(): array
+    {
+        return array_map(fn ($v) => [$v], [
+            'string',
+            0,
+            PHP_INT_MIN,
+            PHP_INT_MAX,
+            -3.14,
+            3.14,
+            true,
+            null,
+            [1, 2, 3],
+            ['a' => 1, 'b' => 2, 'c' => 3],
+            ['a' => ['b' => ['c' => [1, 2, 3]]]],
+        ]);
+    }
+
     public function testReconnect(): void
     {
         self::markTestSkipped('Future functionality');

--- a/tests/integration/IntegrationTest.php
+++ b/tests/integration/IntegrationTest.php
@@ -85,6 +85,12 @@ class IntegrationTest extends \PHPUnit\Framework\TestCase
      * > If it is not possible to return the exact saved value for any reason,
      * > implementing libraries MUST respond with a cache miss rather than
      * > corrupted data.
+     *
+     * Note that this behavior isn't _strictly_ true: it's possible to check
+     * `->has($key)` on the "miss" and infer the value must be false, but this
+     * would require additional roundtrips on all misses, increasing execution
+     * time. Given that the utility of caching literal `false` is quite low,
+     * the overhead does not seem worth it.
      */
     public function testFalseHandling(): void
     {

--- a/tests/integration/SampleObject.php
+++ b/tests/integration/SampleObject.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\Cache;
+
+class SampleObject
+{
+    public function __construct(
+        public int $int,
+        public string $string,
+        public float $float,
+        public bool $bool,
+    ) {
+    }
+}


### PR DESCRIPTION
Set Redis to use PHP serialization if none is configured. Any other value will be left as configured.

This ensures any non-string values are encoded and decoded correctly.