### PR TITLE
Error mode format updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,17 +45,17 @@ $cache = new RedisPsr16($redis);
 A runtime mode can be set via the `$mode` constructor parameter:
 
 ```php
-use Firehed\Cache\RedisPsr16;
+use Firehed\Cache\{ErrorMode, RedisPsr16};
 
-$cache = new RedisPsr16($redis, RedisPsr16::MODE_THROW);
+$cache = new RedisPsr16($redis, ErrorMode::EXCEPTION);
 ```
 
-- `RedisPsr16::MODE_THROW` may throw exceptions on network issues (in the same way directly using the `Redis` extension can).
+- `ErrorMode::EXCEPTION` may throw exceptions on network issues (in the same way directly using the `Redis` extension can).
   Exceptions thrown will implement `Psr\SimpleCache\CacheException`, per PSR-16 requirements.
   This will help expose networking issues and may be beneficial for logging and error handling, but does require calling libraries to handle them.
   _This is the default mode._
 
-- `RedisPsr16::MODE_FAIL` will prevent exceptions from being thrown.
+- `ErrorMode::FAIL` will prevent exceptions from being thrown.
   Any error, including networking errors (where the `Redis` extension throws) will be treated as a failure.
   This could result in misleading behavior around cache misses; if it's important for your application to know the difference between "miss" and "Redis unavailable", do not use this mode.
 

--- a/src/ErrorMode.php
+++ b/src/ErrorMode.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\Cache;
+
+interface ErrorMode
+{
+    public const EXCEPTION = 0;
+    public const FAIL = 1;
+}

--- a/src/ErrorMode.php
+++ b/src/ErrorMode.php
@@ -5,15 +5,7 @@ declare(strict_types=1);
 namespace Firehed\Cache;
 
 if (version_compare(PHP_VERSION, '8.1.0', '>=')) {
-    enum ErrorMode
-    {
-        case EXCEPTION;
-        case FAIL;
-    }
+    class_alias(ErrorModeGTE81::class, ErrorMode::class);
 } else {
-    interface ErrorMode
-    {
-        public const EXCEPTION = 0;
-        public const FAIL = 1;
-    }
+    class_alias(ErrorModeLT81::class, ErrorMode::class);
 }

--- a/src/ErrorMode.php
+++ b/src/ErrorMode.php
@@ -4,8 +4,16 @@ declare(strict_types=1);
 
 namespace Firehed\Cache;
 
-interface ErrorMode
-{
-    public const EXCEPTION = 0;
-    public const FAIL = 1;
+if (version_compare(PHP_VERSION, '8.1.0', '>=')) {
+    enum ErrorMode
+    {
+        case EXCEPTION;
+        case FAIL;
+    }
+} else {
+    interface ErrorMode
+    {
+        public const EXCEPTION = 0;
+        public const FAIL = 1;
+    }
 }

--- a/src/ErrorModeGTE81.php
+++ b/src/ErrorModeGTE81.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\Cache;
+
+enum ErrorModeGTE81
+{
+    case EXCEPTION;
+    case FAIL;
+}

--- a/src/ErrorModeLT81.php
+++ b/src/ErrorModeLT81.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\Cache;
+
+interface ErrorModeLT81
+{
+    public const EXCEPTION = 0;
+    public const FAIL = 1;
+}

--- a/src/RedisPsr16.php
+++ b/src/RedisPsr16.php
@@ -23,13 +23,10 @@ class RedisPsr16 implements CacheInterface
     // Default value on cache miss. This is inherent to the actual Redis driver
     private const MISS_DEFAULT = false;
 
-    public const MODE_THROW = 0;
-    public const MODE_FAIL = 1;
-
     /**
-     * @param self::MODE_* $mode Error handling mode
+     * @param ErrorMode::* $mode Error handling mode
      */
-    public function __construct(private Redis $conn, private int $mode = self::MODE_THROW)
+    public function __construct(private Redis $conn, private int $mode = ErrorMode::EXCEPTION)
     {
         try {
             $this->conn->ping();
@@ -40,8 +37,8 @@ class RedisPsr16 implements CacheInterface
             // Abusing match slightly here, so if a new mode is added in the
             // future, static analysis will find it.
             match ($this->mode) {
-                self::MODE_THROW => throw new Exception(Exception::ERROR_PING, $e),
-                self::MODE_FAIL => null,
+                ErrorMode::EXCEPTION => throw new Exception(Exception::ERROR_PING, $e),
+                ErrorMode::FAIL => null,
             };
         }
     }
@@ -85,8 +82,8 @@ class RedisPsr16 implements CacheInterface
             $raw = $this->conn->mGet($keys);
         } catch (RedisException $e) {
             return match ($this->mode) {
-                self::MODE_THROW => throw new Exception(Exception::ERROR_GONE, $e),
-                self::MODE_FAIL => array_fill_keys($keys, $default),
+                ErrorMode::EXCEPTION => throw new Exception(Exception::ERROR_GONE, $e),
+                ErrorMode::FAIL => array_fill_keys($keys, $default),
             };
         }
         $values = ($default === self::MISS_DEFAULT)
@@ -160,7 +157,7 @@ class RedisPsr16 implements CacheInterface
     }
 
     /**
-     * @param self::MODE_* $mode Error handling mode
+     * @param ErrorMode::* $mode Error handling mode
      */
     public function setMode(int $mode): void
     {
@@ -173,8 +170,8 @@ class RedisPsr16 implements CacheInterface
     private function handleException(RedisException $e): bool
     {
         return match ($this->mode) {
-            self::MODE_THROW => throw new Exception(Exception::ERROR_GONE, $e),
-            self::MODE_FAIL => false,
+            ErrorMode::EXCEPTION => throw new Exception(Exception::ERROR_GONE, $e),
+            ErrorMode::FAIL => false,
         };
     }
 }

--- a/tests/unit/ModeFailTest.php
+++ b/tests/unit/ModeFailTest.php
@@ -42,7 +42,7 @@ class ModeFailTest extends \PHPUnit\Framework\TestCase
             $this->redis->method($method)
                 ->willThrowException($ex);
         }
-        $this->cache = new RedisPsr16($this->redis, RedisPsr16::MODE_FAIL);
+        $this->cache = new RedisPsr16($this->redis, ErrorMode::FAIL);
     }
 
     public function testConstructDoesNotThrow(): void
@@ -51,7 +51,7 @@ class ModeFailTest extends \PHPUnit\Framework\TestCase
         $redis = $this->createMock(Redis::Class);
         $redis->method('ping')
             ->willThrowException(new RedisException());
-        $cache = new RedisPsr16($redis, RedisPsr16::MODE_FAIL);
+        $cache = new RedisPsr16($redis, ErrorMode::FAIL);
         self::assertInstanceOf(CacheInterface::class, $cache);
     }
 

--- a/tests/unit/ModeThrowTest.php
+++ b/tests/unit/ModeThrowTest.php
@@ -39,7 +39,7 @@ class ModeThrowTest extends \PHPUnit\Framework\TestCase
             $this->redis->method($method)
                 ->willThrowException($ex);
         }
-        $this->cache = new RedisPsr16($this->redis, RedisPsr16::MODE_THROW);
+        $this->cache = new RedisPsr16($this->redis, ErrorMode::EXCEPTION);
     }
 
     public function testConstructThrows(): void
@@ -49,7 +49,7 @@ class ModeThrowTest extends \PHPUnit\Framework\TestCase
         $redis->method('ping')
             ->willThrowException(new RedisException());
         self::expectException(CacheException::class);
-        new RedisPsr16($redis, RedisPsr16::MODE_THROW);
+        new RedisPsr16($redis, ErrorMode::EXCEPTION);
     }
 
     public function testGetThrows(): void

--- a/tests/unit/RedisPsr16Test.php
+++ b/tests/unit/RedisPsr16Test.php
@@ -322,7 +322,7 @@ class RedisPsr16Test extends \PHPUnit\Framework\TestCase
             // no-op
         }
 
-        $this->cache->setMode(RedisPsr16::MODE_FAIL);
+        $this->cache->setMode(ErrorMode::FAIL);
         self::assertNull($this->cache->get('key'));
     }
 


### PR DESCRIPTION
This changes the error mode configuration into its file, permitting the use of native enums in PHP 8.1 and falling back to interface constants of the same name in 8.0.