### PR TITLE
Widen simple cache

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,10 @@ jobs:
         dependencies:
           - 'high'
           - 'low'
+        simple-cache:
+          - '1.0'
+          - '2.0'
+          - '3.0'
         php:
           - '8.0'
           - '8.1'
@@ -70,6 +74,9 @@ jobs:
           --no-suggest
           --prefer-dist
           --prefer-lowest
+
+      - name: Install specific simple-cache version
+        run: composer update psr/simple-cache:^${{ matrix.simple-cache }} ${{ matrix.dependencies == 'low' && '--prefer-lowest' || '' }}
 
       - name: PHPUnit
         env:

--- a/composer.json
+++ b/composer.json
@@ -34,12 +34,12 @@
         "sort-packages": true
     },
     "provide": {
-        "psr/simple-cache-implementation": "^1.0.0"
+        "psr/simple-cache-implementation": "^1.0 || ^2.0 || ^3.0"
     },
     "require": {
         "php": "^8.0",
         "ext-redis": "^5.3",
-        "psr/simple-cache": "^1.0"
+        "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "phpstan/phpstan": "^0.12.88",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,11 +3,6 @@ includes:
 parameters:
     excludePaths:
         - vendor
-    ignoreErrors:
-        # This is unfixable without an upstream change to the interface.
-        - '#Multiple\(\) should be contravariant with parameter#'
-        # Same
-        - '#^Parameter \#1 \$exception of method PHPUnit\\Framework\\TestCase::expectException\(\) expects class-string<Throwable>, string given.$#'
     level: max
     paths:
         - .


### PR DESCRIPTION
Spin-off of #18 - this expands the CI test matrix to validate that the library works with all supported versions.